### PR TITLE
feat: init navigation with creating home and brush screens

### DIFF
--- a/app/src/main/java/com/example/androidplayground/MainActivity.kt
+++ b/app/src/main/java/com/example/androidplayground/MainActivity.kt
@@ -11,6 +11,8 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.navigation.compose.rememberNavController
+import com.example.androidplayground.ui.navigation.AndroidPlaygroundNavHost
 import com.example.androidplayground.ui.theme.AndroidPlaygroundTheme
 
 class MainActivity : ComponentActivity() {
@@ -18,14 +20,20 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         setContent {
-            AndroidPlaygroundTheme {
-                Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-                    Greeting(
-                        name = "Android",
-                        modifier = Modifier.padding(innerPadding)
-                    )
-                }
-            }
+            AndroidPlaygroundApp()
+        }
+    }
+}
+
+@Composable
+fun AndroidPlaygroundApp() {
+    AndroidPlaygroundTheme {
+        val navController = rememberNavController()
+        Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
+            AndroidPlaygroundNavHost(
+                navController = navController,
+                modifier = Modifier.padding(innerPadding)
+            )
         }
     }
 }

--- a/app/src/main/java/com/example/androidplayground/ui/brush/BrushScreen.kt
+++ b/app/src/main/java/com/example/androidplayground/ui/brush/BrushScreen.kt
@@ -1,0 +1,9 @@
+package com.example.androidplayground.ui.brush
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+
+@Composable
+fun BrushScreen() {
+    Text("TODO")
+}

--- a/app/src/main/java/com/example/androidplayground/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/androidplayground/ui/home/HomeScreen.kt
@@ -1,0 +1,13 @@
+package com.example.androidplayground.ui.home
+
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import com.example.androidplayground.ui.navigation.Brush
+
+@Composable
+fun HomeScreen(onClickBrush: () -> Unit) {
+    TextButton(onClickBrush) {
+        Text(Brush.title)
+    }
+}

--- a/app/src/main/java/com/example/androidplayground/ui/navigation/Destinations.kt
+++ b/app/src/main/java/com/example/androidplayground/ui/navigation/Destinations.kt
@@ -1,0 +1,16 @@
+package com.example.androidplayground.ui.navigation
+
+sealed interface Destination {
+    val route: String
+    val title: String
+}
+
+data object Home : Destination {
+    override val route = "home"
+    override val title = "Home"
+}
+
+data object Brush : Destination {
+    override val route = "brush"
+    override val title = "Brush"
+}

--- a/app/src/main/java/com/example/androidplayground/ui/navigation/NavHost.kt
+++ b/app/src/main/java/com/example/androidplayground/ui/navigation/NavHost.kt
@@ -1,0 +1,21 @@
+package com.example.androidplayground.ui.navigation
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import com.example.androidplayground.ui.brush.BrushScreen
+import com.example.androidplayground.ui.home.HomeScreen
+
+@Composable
+fun AndroidPlaygroundNavHost(navController: NavHostController, modifier: Modifier = Modifier) {
+    NavHost(navController = navController, startDestination = Home.route, modifier = modifier) {
+        composable(Home.route) {
+            HomeScreen(onClickBrush = { navController.navigate(Brush.route) })
+        }
+        composable(Brush.route) {
+            BrushScreen()
+        }
+    }
+}


### PR DESCRIPTION
Init navigation with creating home screen and create an empty brush scrren, the brush screen's content will be in next PR.

 